### PR TITLE
Fixed response NSCOUNT/ARCOUNT

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -72,8 +72,10 @@ Query.prototype.encode = function encode() {
                         flags: this._flags,
                         qdCount: this._qdCount,
                         anCount: this._anCount,
-                        nsCount: this._nsCount,
-                        srCount: this._srCount
+                        // nsCount: this._nsCount,
+                        // srCount: this._srCount
+                        nsCount: this._authority ? this._authority.length : 0,
+                        srCount: this._additional ? this._additional.length : 0
                 },
                 question: this._question,
                 answers: this._answers,


### PR DESCRIPTION
_authority and _additional are never filled with data but at response, the corresponding counters are not 0 but contain the counters from the request which will produce a malformed response